### PR TITLE
Fixing 4kb+ FileGroup length issue with filescrn.exe calls

### DIFF
--- a/DeployCryptoBlocker.ps1
+++ b/DeployCryptoBlocker.ps1
@@ -37,6 +37,48 @@ function ConvertFrom-Json20([Object] $obj)
     $serializer = New-Object System.Web.Script.Serialization.JavaScriptSerializer
     return ,$serializer.DeserializeObject($obj)
 }
+
+Function New-CBArraySplit {
+
+    param(
+        $extArr,
+        $depth = 1
+    )
+
+    $extArr = $extArr | Sort-Object -Unique
+
+    # Concatenate the input array
+    $conStr = $extArr -join ','
+    $outArr = @()
+
+    # If the input string breaks the 4Kb limit
+    If ($conStr.Length -gt 4096) {
+        # Pull the first 4096 characters and split on comma
+        $conArr = $conStr.SubString(0,4096).Split(',')
+        # Find index of the last guaranteed complete item of the split array in the input array
+        $endIndex = [array]::IndexOf($extArr,$conArr[-2])
+        # Build shorter array up to that indexNumber and add to output array
+        $shortArr = $extArr[0..$endIndex]
+        $outArr += [psobject] @{
+            index = $depth
+            array = $shortArr
+        }
+
+        # Then call this function again to split further
+        $newArr = $extArr[($endindex + 1)..($extArr.Count -1)]
+        $outArr += New-CBArraySplit $newArr -depth ($depth + 1)
+        
+        return $outArr
+    }
+    # If the concat string is less than 4096 characters already, just return the input array
+    Else {
+        return [psobject] @{
+            index = $depth
+            array = $extArr
+        }  
+    }
+}
+
 ################################ Functions ################################
 
 # Add to all drives
@@ -93,6 +135,12 @@ $fileScreenName = "CryptoBlockerScreen"
 $webClient = New-Object System.Net.WebClient
 $jsonStr = $webClient.DownloadString("https://fsrm.experiant.ca/api/v1/get")
 $monitoredExtensions = @(ConvertFrom-Json20($jsonStr) | % { $_.filters })
+
+# Split the $monitoredExtensions array into fileGroups of less than 4kb to allow processing by filescrn.exe
+$fileGroups = New-CBArraySplit $monitoredExtensions
+ForEach ($group in $fileGroups) {
+    $group | Add-Member -MemberType NoteProperty -Name fileGroupName -Value "$FileGroupName$($group.index)"
+}
 
 $scriptFilename = "C:\FSRMScripts\KillUserSession.ps1"
 $batchFilename = "C:\FSRMScripts\KillUserSession.bat"
@@ -206,13 +254,22 @@ $eventConf | Out-File $eventConfFilename
 Write-Host "Writing temporary FSRM Command configuration to location [$cmdConfFilename].."
 $cmdConf | Out-File $cmdConfFilename
 
-Write-Host "Adding/replacing File Group [$fileGroupName] with monitored file [$($monitoredExtensions -Join ",")].."
-&filescrn.exe filegroup Delete /Filegroup:$fileGroupName /Quiet
-&filescrn.exe Filegroup Add "/Filegroup:$fileGroupName" "/Members:$($monitoredExtensions -Join "|")"
+# Perform these steps for each of the 4KB limit split fileGroups
+ForEach ($group in $fileGroups) {
+    Write-Host "Adding/replacing File Group [$($group.fileGroupName)] with monitored file [$($group.array -Join ",")].."
+    &filescrn.exe filegroup Delete "/Filegroup:$($group.fileGroupName)" /Quiet
+    &filescrn.exe Filegroup Add "/Filegroup:$($group.fileGroupName)" "/Members:$($group.array -Join '|')"
+}
 
 Write-Host "Adding/replacing File Screen Template [$fileTemplateName] with Event Notification [$eventConfFilename] and Command Notification [$cmdConfFilename].."
 &filescrn.exe Template Delete /Template:$fileTemplateName /Quiet
-&filescrn.exe Template Add "/Template:$fileTemplateName" "/Add-Filegroup:$fileGroupName" "/Add-Notification:E,$eventConfFilename" "/Add-Notification:C,$cmdConfFilename" /Type:Passive
+# Build the argument list with all required fileGroups
+$screenArgs = 'Template','Add',"/Template:$fileTemplateName"
+ForEach ($group in $fileGroups) {
+    $screenArgs += "/Add-Filegroup:$($group.fileGroupName)"
+}
+$screenArgs += "/Add-Notification:E,$eventConfFilename","/Add-Notification:C,$cmdConfFilename",'/Type:Passive'
+&filescrn.exe $screenArgs
 
 Write-Host "Adding/replacing File Screens.."
 $drivesContainingShares | % {


### PR DESCRIPTION
Adding a new function 'New-CBArraySplit' to split the downloaded extensions into FileGroups of less than 4KB in length, and then create and add these FileGroups to the File Screen Template. Tested with up to 10x current length of JSON list, seems to work fine.
